### PR TITLE
Remove bottle :unneeded directive to silence brew warning

### DIFF
--- a/Formula/secrethub-cli.rb
+++ b/Formula/secrethub-cli.rb
@@ -3,7 +3,6 @@ class SecrethubCli < Formula
   desc "Command-line interface for SecretHub"
   homepage "https://secrethub.io"
   version "0.43.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/secrethub/secrethub-cli/releases/download/v0.43.0/secrethub-v0.43.0-darwin-amd64.tar.gz"


### PR DESCRIPTION
Homebrew outputs the following warning

```zsh
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the secrethub/tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/secrethub/homebrew-tools/Formula/secrethub-cli.rb:6
```

According to [this discussion](https://github.com/Homebrew/discussions/discussions/2311#discussioncomment-1507233), the change is safe.

Other similar fixes:
https://github.com/derailed/homebrew-k9s/pull/4
https://github.com/minamijoyo/homebrew-tfschema/commit/bc61cd182cd921da608692e199e2f6bec57382f9
https://github.com/goreleaser/goreleaser/pull/2591
https://github.com/hashicorp/homebrew-tap/pull/157
https://github.com/depscloud/homebrew-tap/pull/3
